### PR TITLE
Transfer of Webhook call from Issue Cred Tests to Aca-py Backchannel

### DIFF
--- a/aries-test-harness/agent_backchannel_client.py
+++ b/aries-test-harness/agent_backchannel_client.py
@@ -95,13 +95,13 @@ def connection_status(agent_url, connection_id, status_txt):
     print("From", agent_url, "Expected state", status_txt, "but received", state, ", with a response status of", resp_status)
     return False
 
-def issue_credential_status(agent_url, cred_ex_id, status_txt):
+def issue_credential_status(agent_url, thread_id, status_txt):
     sleep(0.2)
     state = "None"
     if type(status_txt) != list:
         status_txt = [status_txt]
     for i in range(5):
-        (resp_status, resp_text) = agent_backchannel_GET(agent_url + "/agent/command/", "issue-credential", id=cred_ex_id)
+        (resp_status, resp_text) = agent_backchannel_GET(agent_url + "/agent/command/", "issue-credential", id=thread_id)
         if resp_status == 200:
             resp_json = json.loads(resp_text)
             state = resp_json["state"]


### PR DESCRIPTION
There are now no Aca-py Agent Webhook calls in Issue Cred Test code. The Issue Cred Test code now only references Thread IDs and Connection Ids. Cred Ex IDs are not used. The Aca-py Backchannel now swaps out the thread ID with the cred_ex_id by reaching into the data stored by the Agents webhook. 

The removal of Webhook calls in Present Proof tests will come in a separate PR.  

Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>