### PR TITLE
Connectionless proof test dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,5 +20,51 @@
         "appProject": "${workspaceFolder}/aries-backchannels/dotnet/server/DotNet.Backchannel.csproj"
       }
     }
+    {
+        "name": "Python: Current File",
+        "type": "python",
+        "request": "launch",
+        "program": "${file}",
+        "console": "integratedTerminal",
+        "cwd": "${workspaceFolder}/aries-backchannels",
+        "args" : ["-p", "8020"],
+        "env": {
+            "LEDGER_URL": "http://localhost:9000"
+        },
+    },
+    {
+        "name": "Python: Behave current file",
+        "type": "python",
+        "request": "launch",
+        "module": "behave",
+        "console": "integratedTerminal",
+        "cwd": "${workspaceFolder}/aries-test-harness",
+        "args": [
+            "${file}",
+            "--tags=@T002-API10-RFC0037",
+            "-k",
+            "-D",
+            "Acme=http://0.0.0.0:8020",
+            "-D",
+            "Bob=http://0.0.0.0:8030",
+            "-D",
+            "Mallory=http://0.0.0.0:8040",
+            "-D",
+            "Faber=http://0.0.0.0:8050"
+        ]
+    },
+    {
+        "name": "Python: Remote Attach",
+        "type": "python",
+        "request": "attach",
+        "pathMappings": [
+            {
+                "localRoot": "${workspaceFolder}/aries-test-harness/aries-backchannels",
+                "remoteRoot": "/aries-backchannels"
+            } 
+        ],
+        "port": 5678,
+        "host": "127.0.0.1"
+    },
   ]
 }

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -319,7 +319,8 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     or operation == "verify-presentation"
                     or operation == "remove"
                 ):
-                    if (operation not in "send-presentation" or operation not in "send-request") and "~service" not in data:
+                    
+                    if (operation not in "send-presentation" or operation not in "send-request") and (data is None or "~service" not in data):
                         # swap thread id for pres ex id from the webhook
                         pres_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "presentation-msg", "presentation_exchange_id")
                     else:
@@ -331,8 +332,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     agent_operation = "/present-proof/" + operation
             
             log_msg(agent_operation, data)
-            # Format the message data that came from the test, to what the Aca-py admin api expects.
-            data = self.map_test_json_to_admin_api_json(op["topic"], operation, data)
+
+            if data is not None:
+                # Format the message data that came from the test, to what the Aca-py admin api expects.
+                data = self.map_test_json_to_admin_api_json(op["topic"], operation, data)
 
             (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
 
@@ -708,6 +711,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
             else:
                 admin_data = data
+
+            # Add on the service decorator if it exists.
+            if "~service" in data: 
+                admin_data["~service"] = data["~service"]
 
             return (admin_data)
 

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -319,10 +319,14 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     or operation == "verify-presentation"
                     or operation == "remove"
                 ):
-                    #pres_ex_id = rec_id
-                    # swap thread id for pres ex id from the webhook
-                    pres_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "presentation-msg", "presentation_exchange_id")
+                    if (operation not in "send-presentation" or operation not in "send-request") and "~service" not in data:
+                        # swap thread id for pres ex id from the webhook
+                        pres_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "presentation-msg", "presentation_exchange_id")
+                    else:
+                        # swap the thread id for the pres ex id in the service decorator (this is a connectionless proof)
+                        pres_ex_id = data["~service"]["recipientKeys"][0]
                     agent_operation = "/present-proof/records/" + pres_ex_id + "/" + operation
+
                 else:
                     agent_operation = "/present-proof/" + operation
             

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -309,6 +309,8 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         elif op["topic"] == "proof":
             operation = op["operation"]
+            if operation == "create-send-connectionless-request":
+                operation = "create-request"
             if rec_id is None:
                 agent_operation = "/present-proof/" + operation
             else:
@@ -630,7 +632,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
 
         if topic == "proof":
 
-            if operation == "send-request":
+            if operation == "send-request" or operation == "create-request":
                 
                 if data.get("presentation_proposal", {}).get("request_presentations~attach", {}).get("data", {}).get("requested_values") == None:
                     requested_attributes = {}
@@ -651,18 +653,30 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     proof_request_version = "1.0"
                 else:
                     proof_request_version = data["presentation_proposal"]["request_presentations~attach"]["data"]["version"]
-
-                admin_data = {
-                    "comment": data["presentation_proposal"]["comment"],
-                    "trace": False,
-                    "connection_id": data["connection_id"],
-                    "proof_request": {
-                        "name": proof_request_name,
-                        "version": proof_request_version,
-                        "requested_attributes": requested_attributes,
-                        "requested_predicates": requested_predicates
+                
+                if "connection_id" in data:
+                    admin_data = {
+                        "comment": data["presentation_proposal"]["comment"],
+                        "trace": False,
+                        "connection_id": data["connection_id"],
+                        "proof_request": {
+                            "name": proof_request_name,
+                            "version": proof_request_version,
+                            "requested_attributes": requested_attributes,
+                            "requested_predicates": requested_predicates
+                        }
                     }
-                }
+                else:
+                    admin_data = {
+                        "comment": data["presentation_proposal"]["comment"],
+                        "trace": False,
+                        "proof_request": {
+                            "name": proof_request_name,
+                            "version": proof_request_version,
+                            "requested_attributes": requested_attributes,
+                            "requested_predicates": requested_predicates
+                        }
+                    }
 
             elif operation == "send-presentation":
                 

--- a/aries-backchannels/backchannel_operations.csv
+++ b/aries-backchannels/backchannel_operations.csv
@@ -72,5 +72,7 @@ rfc,command,response,topic,method,operation,id,data,description,id_details,data_
 0037 Present Proof,X,,proof,POST,send-request,Y,Y,Send a proof request in reference to a proposal,pres_exchange_id,proof_request,pres_exchange_id
 0037 Present Proof,X,,proof,POST,send-presentation,Y,Y,Send a proof presentation,pres_exchange_id,proof_presentation,pres_exchange_id
 0037 Present Proof,X,,proof,POST,verify-presentation,Y,,Verify a received proof presentation,pres_exchange_id,,status
+0037 Present Proof,X,,proof,POST,create-send-connectionless-request,,Y,Send a proof request in reference to a proposal,,proposal,pres_exchange_id
 0037 Present Proof,X,,proof,GET,,Y,,Get a stored presentation from the wallet ,presentation_id,,presentation
 0036 Present Proof,X,,proof,GET,,Y,,Fetch a specific credential by ID ,presentation_exchange_id,,presentation_exchange_id
+0037 Present Proof,X,,proof,POST,create-send-connectionless-request,,Y,Send a proof request in reference to a proposal,,proposal,pres_exchange_id

--- a/aries-backchannels/data/backchannel_operations.csv
+++ b/aries-backchannels/data/backchannel_operations.csv
@@ -72,4 +72,5 @@ rfc,command,response,topic,method,operation,id,data,description,id_details,data_
 0037 Present Proof,X,,proof,POST,send-request,Y,Y,Send a proof request in reference to a proposal,pres_exchange_id,proof_request,pres_exchange_id
 0037 Present Proof,X,,proof,POST,send-presentation,Y,Y,Send a proof presentation,pres_exchange_id,proof_presentation,pres_exchange_id
 0037 Present Proof,X,,proof,POST,verify-presentation,Y,,Verify a received proof presentation,pres_exchange_id,,status
+0037 Present Proof,X,,proof,POST,create-send-connectionless-request,,Y,Send a proof request in reference to a proposal,,proposal,pres_exchange_id
 0037 Present Proof,X,,proof,GET,,Y,,Get a stored presentation from the holders wallet ,presentation_id,,presentation

--- a/aries-test-harness/features/0037-present-proof.feature
+++ b/aries-test-harness/features/0037-present-proof.feature
@@ -72,7 +72,7 @@ Feature: Aries agent present proof functions RFC 0037
          | issuer | credential_data      | request for proof            | presentation                |
          | Faber  | Data_BI_HealthValues | proof_request_health_consent | presentation_health_consent |
 
-   @T002-API10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview
+   @T002-API10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview @Indy
    Scenario Outline: Present Proof where the prover and verifier are connectionless, the prover does not propose a presentation of the proof, and is acknowledged
       Given "2" agents
          | name  | role     |
@@ -89,7 +89,7 @@ Feature: Aries agent present proof functions RFC 0037
          | issuer |
          | Acme   |
 
-   @T003-API10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview
+   @T003-API10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview @Indy
    Scenario Outline: Present Proof where the prover has proposed the presentation of proof and is acknowledged
       Given "2" agents
          | name  | role     |

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -158,20 +158,20 @@ def step_impl(context, verifier, prover):
             }
         }
 
-    if ('connectionless' in context) and (context.connectionless == True):
-        resp_json = json.loads(resp_text)
+    # if ('connectionless' in context) and (context.connectionless == True):
+    #     resp_json = json.loads(resp_text)
 
-        presentation_proposal["~service"] = {
-                "recipientKeys": [
-                    resp_json["presentation_exchange_id"]
-                ],
-                "routingKeys": None,
-                "serviceEndpoint": context.verifier_url
-                }
+    #     presentation_proposal["~service"] = {
+    #             "recipientKeys": [
+    #                 resp_json["presentation_exchange_id"]
+    #             ],
+    #             "routingKeys": None,
+    #             "serviceEndpoint": context.verifier_url
+    #             }
 
 
-    # send presentation request
-    (resp_status, resp_text) = agent_backchannel_POST(context.verifier_url + "/agent/command/", "proof", operation="send-request", data=presentation_proposal)
+        # send presentation request
+        (resp_status, resp_text) = agent_backchannel_POST(context.verifier_url + "/agent/command/", "proof", operation="send-request", data=presentation_proposal)
     
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -131,21 +131,36 @@ def step_impl(context, verifier, prover):
                     }
                 }
 
-    presentation_proposal = {
-        "connection_id": context.connection_id_dict[verifier][prover],
-        "presentation_proposal": {
-            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/request-presentation",
-            "comment": "This is a comment for the request for presentation.",
-            "request_presentations~attach": {
-                "@id": "libindy-request-presentation-0",
-                "mime-type": "application/json",
-                "data":  data
+    if ('connectionless' in context) and (context.connectionless == True):
+        presentation_proposal = {
+            "presentation_proposal": {
+                "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/request-presentation",
+                "comment": "This is a comment for the request for presentation.",
+                "request_presentations~attach": {
+                    "@id": "libindy-request-presentation-0",
+                    "mime-type": "application/json",
+                    "data":  data
+                }
             }
         }
-    }
+        (resp_status, resp_text) = agent_backchannel_POST(context.verifier_url + "/agent/command/", "proof", operation="create-send-connectionless-request", data=presentation_proposal)
+    else:
+        presentation_proposal = {
+            "connection_id": context.connection_id_dict[verifier][prover],
+            "presentation_proposal": {
+                "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/request-presentation",
+                "comment": "This is a comment for the request for presentation.",
+                "request_presentations~attach": {
+                    "@id": "libindy-request-presentation-0",
+                    "mime-type": "application/json",
+                    "data":  data
+                }
+            }
+        }
 
-    # send presentation request
-    (resp_status, resp_text) = agent_backchannel_POST(context.verifier_url + "/agent/command/", "proof", operation="send-request", data=presentation_proposal)
+        # send presentation request
+        (resp_status, resp_text) = agent_backchannel_POST(context.verifier_url + "/agent/command/", "proof", operation="send-request", data=presentation_proposal)
+    
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     resp_json = json.loads(resp_text)
     # check the state of the presentation from the verifiers perspective
@@ -156,7 +171,6 @@ def step_impl(context, verifier, prover):
 
     # check the state of the presentation from the provers perspective
     assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
-    #assert present_proof_status(context.prover_url, context.presentation_thread_id, "request-received")
 
 @when('"{verifier}" sends a {request_for_proof} presentation to "{prover}"')
 def step_impl(context, verifier, request_for_proof, prover):
@@ -249,3 +263,86 @@ def step_impl(context, verifier):
 def step_impl(context, prover):
     # check the state of the presentation from the prover's perspective
     assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "done")
+
+@given('"{verifier}" and "{prover}" do not have a connection')
+def step_impl(context, verifier, prover):
+    context.connectionless = True
+
+@when('"{prover}" doesn’t want to reveal what was requested so makes a presentation proposal')
+def step_impl(context, prover):
+   
+    # check for a schema template already loaded in the context. If it is, it was loaded from an external Schema, so use it.
+    if "request_for_proof" in context:
+        data = context.request_for_proof
+    else:   
+        data = {
+                    "requested_values": {
+                        "attr_1": {
+                            "name": "attr_1",
+                            "restrictions": [
+                                {
+                                    "schema_name": "test_schema." + context.issuer_name,
+                                    "schema_version": "1.0.0"
+                                }
+                            ]
+                        }
+                    }
+                }
+
+    if ('connectionless' in context) and (context.connectionless == True):
+        presentation_proposal = {
+            "presentation_proposal": {
+                "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/request-presentation",
+                "comment": "This is a comment for the request for presentation.",
+                "request_presentations~attach": {
+                    "@id": "libindy-request-presentation-0",
+                    "mime-type": "application/json",
+                    "data": data
+                }
+            }
+        }
+    else:
+        presentation_proposal = {
+            "connection_id": context.connection_id_dict[prover][context.verifier_name],
+            "presentation_proposal": {
+                "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/request-presentation",
+                "comment": "This is a comment for the request for presentation.",
+                "request_presentations~attach": {
+                    "@id": "libindy-request-presentation-0",
+                    "mime-type": "application/json",
+                    "data": data
+                }
+            }
+        }
+
+        
+
+    # send presentation proposal
+    (resp_status, resp_text) = agent_backchannel_POST(context.prover_url + "/agent/command/", "proof", operation="send-proposal", data=presentation_proposal)
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+    resp_json = json.loads(resp_text)
+    # check the state of the presentation from the verifiers perspective
+    assert resp_json["state"] == "proposal-sent"
+
+    # save off anything that is returned in the response to use later?
+    context.presentation_thread_id = resp_json["thread_id"]
+
+    # check the state of the presentation from the provers perspective
+    assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "proposal-received")
+
+
+@when(u'"{verifier}" agrees to continue so sends a request for proof presentation')
+def step_impl(context, verifier):
+    # send presentation request
+    (resp_status, resp_text) = agent_backchannel_POST(context.verifier_url + "/agent/command/", "proof", operation="send-request", id=context.presentation_thread_id, data=presentation_proposal)
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+    resp_json = json.loads(resp_text)
+    # check the state of the presentation from the verifiers perspective
+    assert resp_json["state"] == "request-sent"
+
+    # save off anything that is returned in the response to use later?
+    context.presentation_thread_id = resp_json["thread_id"]
+
+    # check the state of the presentation from the provers perspective
+    assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "request-received")
+    #assert present_proof_status(context.prover_url, context.presentation_thread_id, "request-received")


### PR DESCRIPTION
The updates in this submission do not make the connectionless test work. These changes do not affect other tests negatively. This work will be picked back up when acapy supports connectionless proofs in the prover role. 
The work will be done in issue #90.