### PR TITLE
removed indyisms from feature files

### DIFF
--- a/aries-test-harness/features/0036-issue-credential.feature
+++ b/aries-test-harness/features/0036-issue-credential.feature
@@ -2,10 +2,7 @@ Feature: Aries agent issue credential functions RFC 0036
 
   Background: create a schema and credential definition in order to issue a credential
     Given "Acme" has a public did
-    When "Acme" creates a new schema
-    And "Acme" creates a new credential definition
-    Then "Acme" has an existing schema
-    And "Acme" has an existing credential definition
+    And "Acme" is ready to issue a credential
 
   @T001-AIP10-RFC0036 @AcceptanceTest @P1 @Indy
   Scenario: Issue a credential with the Holder beginning with a proposal

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -47,6 +47,17 @@ def step_impl(context, issuer):
     else:
         context.issuer_did_dict = {context.schema['schema_name']: issuer_did["did"]}
 
+@given('"{issuer}" is ready to issue a credential')
+def step_impl(context, issuer):
+    # TODO remove these references to schema and cred def, move them to one call to the API and let the Backchannel take care of
+    # what to do to be ready to issie a credential
+    context.execute_steps('''
+      When "''' + issuer + '''" creates a new schema
+       And "''' + issuer + '''" creates a new credential definition
+      Then "''' + issuer + '''" has an existing schema
+       And "''' + issuer + '''" has an existing credential definition
+    ''')
+
 @when('"{issuer}" creates a new schema')
 def step_impl(context, issuer):
     issuer_url = context.config.userdata.get(issuer)
@@ -330,8 +341,10 @@ def step_impl(context, holder):
 
         # Make sure the issuer is not holding the credential
         # get the credential from the holders wallet
-        (resp_status, resp_text) = agent_backchannel_GET(context.issuer_url + "/agent/command/", "credential", id=context.credential_id_dict[context.schema['schema_name']])
-        assert resp_status == 404, f'resp_status {resp_status} is not 404; {resp_text}'
+        # TODO this expected error is not displaying in the agent output until after all the tests are executed. Uncomment this out when
+        # there is a solution to the error messaging happening at the end. 
+        #(resp_status, resp_text) = agent_backchannel_GET(context.issuer_url + "/agent/command/", "credential", id=context.credential_id_dict[context.schema['schema_name']])
+        #assert resp_status == 404, f'resp_status {resp_status} is not 404; {resp_text}'
 
 
 


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

The schema and credential def has been removed from the feature files. Anyone running the tests now should not see these Indyisms in the test output. This is just superficial however, the step code still references the old steps and the removal of these and pushing things into the backchannels will come in another PR.

This submission also includes the suppression of a 404 error message that was displaying after all the tests ran. This error is expected and is a part of the tests but is not displaying in the output when it happens. This check in the test is now disabled until the logs are fixed. 