### PR TITLE
Revocation test dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ cd aries-agent-test-harness
 ./manage run -d acapy -t @AcceptanceTest -t ~@wip
 
 ```
+If running the Credential Revocation tests, which the `./manage run -d acapy -t @AcceptanceTest -t ~@wip` command does, make sure the Tail Server is running.
+```bash
+git clone https://github.com/bcgov/indy-tails-server
+cd indy-tails-server/docker
+./manage start
+```
 
 The commands take a while to run (you know...building modern apps always means downloading half the internet...), so while you wait, here's what's happening:
 

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -219,15 +219,16 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         pass
 
     async def handle_revocation_registry(self, message):
-        thread_id = message["thread_id"]
-        push_resource(thread_id, "revocation-registry-msg", message)
-        log_msg('Recieved Revocation Registry Webhook message: ' + message) 
+        # registry revoction webhook messages do not contain thread ids.
+        cred_def_id = message["cred_def_id"]
+        push_resource(cred_def_id, "revocation-registry-msg", message)
+        log_msg('Recieved Revocation Registry Webhook message: ' + json.dumps(message)) 
         pass
 
     async def handle_problem_report(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "problem-report-msg", message)
-        log_msg('Recieved Problem Report Webhook message: ' + message) 
+        log_msg('Recieved Problem Report Webhook message: ' + json.dumps(message)) 
         pass
 
     async def swap_thread_id_for_exchange_id(self, thread_id, data_type, id_txt):

--- a/aries-backchannels/acapy/acapy_backchannel.py
+++ b/aries-backchannels/acapy/acapy_backchannel.py
@@ -124,6 +124,21 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             )
         if self.webhook_url:
             result.append(("--webhook-url", self.webhook_url))
+        
+        # This code for Tails Server is included here because aca-py does not support the env var directly yet. 
+        # when it does (and there is talk of supporting YAML) then this code can be removed. 
+        if os.getenv('TAILS_SERVER_URL') is not None:
+            # if the env var is set for tails server then use that.
+            result.append(("--tails-server-base-url", os.getenv('TAILS_SERVER_URL')))
+        else:
+            # if the tails server env is not set use the gov.bc TEST tails server.
+            result.append(("--tails-server-base-url", "https://tails-server-test.pathfinder.gov.bc.ca"))
+        
+        # This code for log level is included here because aca-py does not support the env var directly yet. 
+        # when it does (and there is talk of supporting YAML) then this code can be removed. 
+        if os.getenv('LOG_LEVEL') is not None:
+            result.append(("--log-level", os.getenv('LOG_LEVEL')))
+
         #if self.extra_args:
         #    result.extend(self.extra_args)
 
@@ -157,7 +172,7 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             handler = f"handle_{topic}"
             method = getattr(self, handler, None)
             # put a log message here
-            log_msg('Passing payload to handler ' + handler + ' payload is: ' + json.dumps(payload))
+            log_msg('Passing webhook payload to handler ' + handler)
             if method:
                 await method(payload)
             else:
@@ -179,7 +194,10 @@ class AcaPyAgentBackchannel(AgentBackchannel):
     async def handle_issue_credential(self, message):
         thread_id = message["thread_id"]
         push_resource(thread_id, "credential-msg", message)
-        # put a log message here (all the handle_ )
+        #log_msg('Recieved Issue Credential Webhook message: ' + message) 
+        if "revocation_id" in message: # also push as a revocation message 
+            push_resource(thread_id, "revocation-registry-msg", message)
+            log_msg('Issue Credential Webhook message contains revocation info') 
         # TODO wait here to determine the response to the web hook?????
         pass
 
@@ -188,6 +206,18 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         push_resource(thread_id, "presentation-msg", message)
         # put a log message here (all the handle_ )
         # TODO wait here to determine the response to the web hook?????
+        pass
+
+    async def handle_revocation_registry(self, message):
+        thread_id = message["thread_id"]
+        push_resource(thread_id, "revocation-registry-msg", message)
+        log_msg('Recieved Revocation Registry Webhook message: ' + message) 
+        pass
+
+    async def handle_problem_report(self, message):
+        thread_id = message["thread_id"]
+        push_resource(thread_id, "problem-report-msg", message)
+        log_msg('Recieved Problem Report Webhook message: ' + message) 
         pass
 
     async def swap_thread_id_for_exchange_id(self, thread_id, data_type, id_txt):
@@ -296,12 +326,36 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                     # swap thread id for cred ex id from the webhook
                     cred_ex_id = await self.swap_thread_id_for_exchange_id(rec_id, "credential-msg","credential_exchange_id")
                     agent_operation = "/issue-credential/records/" + cred_ex_id + "/" + operation
+                # Make Special provisions for revoke since it is passing multiple query params not just one id.
+                elif (operation == "revoke"):
+                    cred_rev_id = rec_id
+                    rev_reg_id = data["rev_registry_id"]
+                    publish = data["publish_immediately"]
+                    agent_operation = "/issue-credential/" + operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id + "&publish=" + str(publish).lower()
+                    data = None
                 else:
                     agent_operation = "/issue-credential/" + operation
             
             log_msg(agent_operation, data)
             
             (resp_status, resp_text) = await self.admin_POST(agent_operation, data)
+
+            log_msg(resp_status, resp_text)
+            if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
+            return (resp_status, resp_text)
+
+        elif op["topic"] == "revocation":
+            #set the acapyversion to master since work to set it is not complete. Remove when master report proper version
+            #self.acapy_version = "0.5.5-RC"
+            operation = op["operation"]
+            agent_operation, admin_data = await self.get_agent_operation_acapy_version_based(op["topic"], operation, rec_id, data)
+            
+            log_msg(agent_operation, admin_data)
+            
+            if admin_data == None:
+                (resp_status, resp_text) = await self.admin_POST(agent_operation)
+            else:
+                (resp_status, resp_text) = await self.admin_POST(agent_operation, admin_data)
 
             log_msg(resp_status, resp_text)
             if resp_status == 200: resp_text = self.agent_state_translation(op["topic"], None, resp_text)
@@ -518,6 +572,22 @@ class AcaPyAgentBackchannel(AgentBackchannel):
             
             return (resp_status, resp_text)
 
+        elif topic == "revocation-registry" and rec_id:
+            revocation_msg = pop_resource(rec_id, "revocation-registry-msg")
+            i = 0
+            while revocation_msg is None and i < MAX_TIMEOUT:
+                sleep(1)
+                revocation_msg = pop_resource(rec_id, "revocation-registry-msg")
+                i = i + 1
+
+            resp_status = 200
+            if revocation_msg:
+                resp_text = json.dumps(revocation_msg)
+            else:
+                resp_text = "{}"
+
+            return (resp_status, resp_text)
+
         return (501, '501: Not Implemented\n\n'.encode('utf8'))
 
     def _process(self, args, env, loop):
@@ -581,6 +651,9 @@ class AcaPyAgentBackchannel(AgentBackchannel):
         try:
             status = json.loads(status_text)
             ok = isinstance(status, dict) and "version" in status
+            if ok:
+                self.acapy_version= status["version"]
+                print("ACA-py Backchannel running with ACA-py version:", self.acapy_version)
         except json.JSONDecodeError:
             pass
         if not ok:
@@ -814,9 +887,59 @@ class AcaPyAgentBackchannel(AgentBackchannel):
                 elif topic == "issue-credential":
                     data = data.replace(agent_state, self.issueCredentialStateTranslationDict[agent_state])
                 elif topic == "proof":
-                    data = data.replace(agent_state, self.presentProofStateTranslationDict[agent_state])
+                    data = data.replace('"state"' + ": " + '"' + agent_state + '"', '"state"' + ": " + '"' + self.presentProofStateTranslationDict[agent_state] + '"')
             return (data)
 
+    async def get_agent_operation_acapy_version_based(self, topic, operation, rec_id=None, data=None):
+        # Admin api calls may change with acapy releases. For example revocation related calls change
+        # between 0.5.4 and 0.5.5. To be able to handle this the backchannel is made aware of the acapy version
+        # and constructs the calls based off that version
+
+        # construct some number to compare to with > or < instead of listing out the version number
+        # if it starts with zero strip it off
+        # if it ends in alpha or RC, change it to .1 or 1
+        # strip all dots
+        # Does that work if I'm testing 0.5.5.1 hot fix? Just strip off the .1 since there won't be a major change here.
+        descriptiveTrailer = "-RC"
+        comparibleVersion = self.acapy_version
+        if comparibleVersion.startswith("0"):
+            comparibleVersion = comparibleVersion[len("0"):]
+        if "." in comparibleVersion:
+            stringParts = comparibleVersion.split(".")
+            comparibleVersion = "".join(stringParts)
+        if comparibleVersion.endswith(descriptiveTrailer):
+            # This means its not an offical release and came from Master/Main
+            # replace with a .1 so that the number is higher than an offical release
+            comparibleVersion = comparibleVersion.replace(descriptiveTrailer, ".1")
+        #  Make it a number. At this point "0.5.5-RC" should be 55.1. "0.5.4" should be 54.
+        comparibleVersion = float(comparibleVersion)
+
+
+        if (topic == "revocation"):
+            if comparibleVersion > 54:
+                agent_operation = "/revocation/" + operation
+                if "cred_ex_id" in data:
+                    admindata = {
+                        "cred_ex_ed": data["cred_ex_id"],
+                    }
+                else:
+                    admindata = {
+                        "cred_rev_id": data["cred_rev_id"],
+                        "rev_reg_id": data["rev_registry_id"],
+                        "publish": str(data["publish_immediately"]).lower(),
+                    }
+                data = admindata
+            else:
+                agent_operation = "/issue-credential/" + operation
+
+                if (data is not None): # Data should be included with 0.5.4 or lower acapy. Then it takes them as inline parameters.
+                    cred_rev_id = data["cred_rev_id"]
+                    rev_reg_id = data["rev_registry_id"]
+                    publish = data["publish_immediately"]
+                    agent_operation = agent_operation + "?cred_rev_id=" + cred_rev_id + "&rev_reg_id=" + rev_reg_id + "&publish=" + str(publish).lower()
+                    data = None
+
+        return agent_operation, data
 
 async def main(start_port: int, show_timing: bool = False, interactive: bool = True):
 

--- a/aries-backchannels/backchannel_operations.csv
+++ b/aries-backchannels/backchannel_operations.csv
@@ -67,6 +67,19 @@ rfc,command,response,topic,method,operation,id,data,description,id_details,data_
 0036 Issue Credential,X,,issue-credential,POST,store,Y,Y,Send credential acknowledgement with ID ,cred_exchange_id,"offer = {
     ""credential_id"": ""issue-credential exchange id string""
 }",cred_exchange_id
+0011 Revocation,X,,revocation,POST,revoke,Y,Y,revoke an issued credential,cred_rev_id,"revocation = {
+    ""rev_registry_id"": ""revocation registry id string"",
+    ""publish_immediately"": ""Publish revocation now or queue""
+}",cred_exchange_id
+0011 Revocation,X,,revocation,POST,revoke,,Y,revoke an issued credential,cred_rev_id,"revocation = {
+    ""rev_registry_id"": ""revocation registry id string"",
+    ""publish_immediately"": ""Publish revocation now or queue""
+}",cred_exchange_id
+0011 Revocation,X,,revocation,POST,revoke,Y,,revoke an issued credential,cred_rev_id,"revocation = {
+    ""rev_registry_id"": ""revocation registry id string"",
+    ""publish_immediately"": ""Publish revocation now or queue""
+}",cred_exchange_id
+0011 Revocation,X,,revocation-registry,GET,,Y,,Get revocation info from issuers webhook ,thread_id,,revocation_registry
 0036 Issue Credential,X,,credential,GET,,Y,,Get a stored credential from the holders wallet ,credential_id,,credential
 0037 Present Proof,X,,proof,POST,send-proposal,Y,Y,Send a proof proposal,connection_id,proposal,pres_exchange_id
 0037 Present Proof,X,,proof,POST,send-request,Y,Y,Send a proof request in reference to a proposal,pres_exchange_id,proof_request,pres_exchange_id

--- a/aries-backchannels/data/backchannel_operations.csv
+++ b/aries-backchannels/data/backchannel_operations.csv
@@ -67,10 +67,25 @@ rfc,command,response,topic,method,operation,id,data,description,id_details,data_
 0036 Issue Credential,X,,issue-credential,POST,store,Y,Y,Send credential acknowledgement with ID ,cred_exchange_id,"offer = {
     ""credential_id"": ""issue-credential exchange id string""
 }",cred_exchange_id
+0011 Revocation,X,,revocation,POST,revoke,Y,Y,revoke an issued credential,cred_rev_id,"revocation = {
+    ""rev_registry_id"": ""revocation registry id string"",
+    ""publish_immediately"": ""Publish revocation now or queue""
+}",cred_exchange_id
+0011 Revocation,X,,revocation,POST,revoke,,Y,revoke an issued credential,cred_rev_id,"revocation = {
+    ""rev_registry_id"": ""revocation registry id string"",
+    ""publish_immediately"": ""Publish revocation now or queue""
+}",cred_exchange_id
+0011 Revocation,X,,revocation,POST,revoke,Y,,revoke an issued credential,cred_rev_id,"revocation = {
+    ""rev_registry_id"": ""revocation registry id string"",
+    ""publish_immediately"": ""Publish revocation now or queue""
+}",cred_exchange_id
+0011 Revocation,X,,revocation-registry,GET,,Y,,Get revocation info from issuers webhook ,thread_id,,revocation_registry
 0036 Issue Credential,X,,credential,GET,,Y,,Get a stored credential from the holders wallet ,credential_id,,credential
 0037 Present Proof,X,,proof,POST,send-proposal,Y,Y,Send a proof proposal,connection_id,proposal,pres_exchange_id
 0037 Present Proof,X,,proof,POST,send-request,Y,Y,Send a proof request in reference to a proposal,pres_exchange_id,proof_request,pres_exchange_id
 0037 Present Proof,X,,proof,POST,send-presentation,Y,Y,Send a proof presentation,pres_exchange_id,proof_presentation,pres_exchange_id
 0037 Present Proof,X,,proof,POST,verify-presentation,Y,,Verify a received proof presentation,pres_exchange_id,,status
 0037 Present Proof,X,,proof,POST,create-send-connectionless-request,,Y,Send a proof request in reference to a proposal,,proposal,pres_exchange_id
-0037 Present Proof,X,,proof,GET,,Y,,Get a stored presentation from the holders wallet ,presentation_id,,presentation
+0037 Present Proof,X,,proof,GET,,Y,,Get a stored presentation from the wallet ,presentation_id,,presentation
+0036 Present Proof,X,,proof,GET,,Y,,Fetch a specific credential by ID ,presentation_exchange_id,,presentation_exchange_id
+0037 Present Proof,X,,proof,POST,create-send-connectionless-request,,Y,Send a proof request in reference to a proposal,,proposal,pres_exchange_id

--- a/aries-backchannels/python/agent_backchannel.py
+++ b/aries-backchannels/python/agent_backchannel.py
@@ -222,6 +222,7 @@ class AgentBackchannel:
                         data = payload["data"]
                     else:
                         data = None
+                        
                     if "id" in payload:
                         rec_id = payload["id"]
                     elif "cred_ex_id" in payload:

--- a/aries-backchannels/python/requirements.txt
+++ b/aries-backchannels/python/requirements.txt
@@ -6,3 +6,4 @@ python3-indy
 #aries-cloudagent==0.5.2
 ptvsd
 aiohttp
+ConfigArgParse

--- a/aries-test-harness/features/0011-0183-revocation.feature
+++ b/aries-test-harness/features/0011-0183-revocation.feature
@@ -1,22 +1,26 @@
-Feature: Aries agent credential revocation and revocation notification RFC 0011 & 0183
+Feature: Aries agent credential revocation and revocation notification RFC 0011 0183
 
-   @T001-RFC0011 @P1 @AcceptanceTest @Schema_DriversLicense_Revoc @wip @NeedsReview
+   Background: create a schema and credential definition in order to issue a credential
+      Given "Acme" has a public did
+      And "Acme" is ready to issue a credential
+
+   @T001-RFC0011 @P1 @AcceptanceTest @Schema_DriversLicense_Revoc @Indy
    Scenario Outline: Credential revoked by Issuer and Holder attempts to prove
-      Given "3" agents
+      Given "2" agents
          | name  | role     |
-         | Acme  | issuer   |
-         | Bob   | holder   |
+         | Bob   | prover   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
+      And "Bob" has an issued credential from <issuer> with <credential_data>
+      When <issuer> revokes the credential
       And "Faber" sends a <request_for_proof> presentation to "Bob"
       And "Bob" makes the <presentation> of the proof
+      And "Faber" acknowledges the proof
       Then "Bob" has the proof unacknowledged
 
       Examples:
-         | issuer | credential_data   | request_for_proof        | presentation            |
-         | Acme   | Data_DL_MaxValues | proof_request_DL_address | presentation_DL_address |
+         | issuer | credential_data   | request_for_proof              | presentation                  |
+         | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
    @T002-RFC0011 @P1 @AcceptanceTest @Schema_DriversLicense_Revoc @wip @NeedsReview
@@ -27,9 +31,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      And “Acme”issues a new credential to “Bob” with <credential_data_new>
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      And "Acme" issues a new credential to “Bob” with <credential_data_new>
       And "Faber" sends a <request_for_proof> presentation to "Bob"
       And "Bob" makes the <presentation> of the proof
       And "Faber" acknowledges the proof
@@ -48,9 +52,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When "Faber" sends a <request_for_proof> presentation to “Bob"
-      And “Acme” revokes the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Faber" sends a <request_for_proof> presentation to "Bob"
+      And "Acme" revokes the credential
       And "Bob" makes the <presentation> of the proof
       Then "Bob" has the proof unacknowledged
 
@@ -67,9 +71,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      And “Acme”issues a new credential to “Bob” with <credential_data_new>
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      And "Acme" issues a new credential to "Bob" with <credential_data_new>
       And "Faber" sends a <request_for_proof> presentation to "Bob"
       And "Bob" makes the <presentation> of the proof with the revoked credential
       Then "Bob" has the proof unacknowledged
@@ -87,9 +91,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential within <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential within <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       And "Faber" acknowledges the proof
       Then "Bob" has the proof acknowledged
@@ -107,9 +111,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential before <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential before <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       Then "Bob" has the proof unacknowledged
 
@@ -126,9 +130,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential after <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential after <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       And "Faber" acknowledges the proof
       Then "Bob" has the proof acknowledged
@@ -146,9 +150,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential within <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential within <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       And "Faber" acknowledges the proof
       Then "Bob" has the proof acknowledged
@@ -167,10 +171,10 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
+      And "Bob" has an issued credential from "Acme" with <credential_data>
       When <role> revokes the credential
       Then <role> will get an error stating ...
-      And “Bob” can make a proof with the credential
+      And "Bob" can make a proof with the credential
 
       Examples:
          | issuer | credential_data   | role     | request_for_proof        | presentation            |
@@ -186,10 +190,10 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      Then “Acme” receives an error stating …
-      And “Bob” can make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      Then "Acme" receives an error stating …
+      And "Bob" can make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |
@@ -204,12 +208,12 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      And “Faber” has an issued credential from “Acme" with <credential_data_2>
-      When “Acme” revokes “Bob’s: credential
-      And “Acme” revokes “Faber’s” credential
-      Then “Bob” cannot make a proof with the credential
-      And “Faber” cannot make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      And "Faber" has an issued credential from "Acme" with <credential_data_2>
+      When "Acme" revokes "Bob’s" credential
+      And "Acme" revokes "Faber’s" credential
+      Then "Bob" cannot make a proof with the credential
+      And "Faber" cannot make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |
@@ -224,11 +228,11 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      And “Acme” sends a revocation notification
-      Then “Bob” receives the revocation notification
-      And “Bob" cannot make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      And "Acme" sends a revocation notification
+      Then "Bob" receives the revocation notification
+      And "Bob" cannot make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |
@@ -242,16 +246,16 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      And “Faber” has an issued credential from “Acme" with <credential_data_2>
-      When “Acme” revokes “Bob’s: credential
-      And “Acme” sends a revocation notification to Bob
-      And “Acme” revokes “Faber’s” credential
-      And “Acme” sends a revocation notification to Faber
-      Then “Bob” receives the revocation notification
-      And “Faber” receives the revocation notification
-      And “Bob” cannot make a proof with the credential
-      And “Faber” cannot make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      And “Faber” has an issued credential from "Acme" with <credential_data_2>
+      When "Acme" revokes "Bob’s" credential
+      And "Acme" sends a revocation notification to "Bob"
+      And "Acme" revokes "Faber’s" credential
+      And "Acme" sends a revocation notification to "Faber"
+      Then "Bob" receives the revocation notification
+      And "Faber" receives the revocation notification
+      And "Bob" cannot make a proof with the credential
+      And "Faber" cannot make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |

--- a/aries-test-harness/features/0011-0183-revocation.feature
+++ b/aries-test-harness/features/0011-0183-revocation.feature
@@ -1,22 +1,26 @@
-Feature: Aries agent credential revocation and revocation notification RFC 0011 & 0183
+Feature: Aries agent credential revocation and revocation notification RFC 0011 0183
 
-   @T001-RFC0011 @P1 @AcceptanceTest @Schema_DriversLicense_Revoc @wip @NeedsReview
+   Background: create a schema and credential definition in order to issue a credential
+      Given "Acme" has a public did
+      And "Acme" is ready to issue a credential
+
+   @T001-RFC0011 @P1 @AcceptanceTest @Schema_DriversLicense_Revoc @wip @Indy
    Scenario Outline: Credential revoked by Issuer and Holder attempts to prove
-      Given "3" agents
+      Given "2" agents
          | name  | role     |
-         | Acme  | issuer   |
-         | Bob   | holder   |
+         | Bob   | prover   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
+      And "Bob" has an issued credential from <issuer> with <credential_data>
+      When <issuer> revokes the credential
       And "Faber" sends a <request_for_proof> presentation to "Bob"
       And "Bob" makes the <presentation> of the proof
+      And "Faber" acknowledges the proof
       Then "Bob" has the proof unacknowledged
 
       Examples:
-         | issuer | credential_data   | request_for_proof        | presentation            |
-         | Acme   | Data_DL_MaxValues | proof_request_DL_address | presentation_DL_address |
+         | issuer | credential_data   | request_for_proof              | presentation                  |
+         | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
    @T002-RFC0011 @P1 @AcceptanceTest @Schema_DriversLicense_Revoc @wip @NeedsReview
@@ -27,9 +31,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      And “Acme”issues a new credential to “Bob” with <credential_data_new>
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      And "Acme" issues a new credential to “Bob” with <credential_data_new>
       And "Faber" sends a <request_for_proof> presentation to "Bob"
       And "Bob" makes the <presentation> of the proof
       And "Faber" acknowledges the proof
@@ -48,9 +52,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When "Faber" sends a <request_for_proof> presentation to “Bob"
-      And “Acme” revokes the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Faber" sends a <request_for_proof> presentation to "Bob"
+      And "Acme" revokes the credential
       And "Bob" makes the <presentation> of the proof
       Then "Bob" has the proof unacknowledged
 
@@ -67,9 +71,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      And “Acme”issues a new credential to “Bob” with <credential_data_new>
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      And "Acme" issues a new credential to "Bob" with <credential_data_new>
       And "Faber" sends a <request_for_proof> presentation to "Bob"
       And "Bob" makes the <presentation> of the proof with the revoked credential
       Then "Bob" has the proof unacknowledged
@@ -87,9 +91,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential within <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential within <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       And "Faber" acknowledges the proof
       Then "Bob" has the proof acknowledged
@@ -107,9 +111,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential before <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential before <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       Then "Bob" has the proof unacknowledged
 
@@ -126,9 +130,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential after <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential after <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       And "Faber" acknowledges the proof
       Then "Bob" has the proof acknowledged
@@ -146,9 +150,9 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" had an issued credential from “Acme" with <credential_data>
-      And “Acme” has revoked the credential within <timeframe>
-      When "Faber" sends a <request_for_proof> presentation to “Bob” with credential validity during <timeframe>
+      And "Bob" had an issued credential from "Acme" with <credential_data>
+      And "Acme" has revoked the credential within <timeframe>
+      When "Faber" sends a <request_for_proof> presentation to "Bob" with credential validity during <timeframe>
       And "Bob" makes the <presentation> of the proof with the revoked credential
       And "Faber" acknowledges the proof
       Then "Bob" has the proof acknowledged
@@ -167,10 +171,10 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
+      And "Bob" has an issued credential from "Acme" with <credential_data>
       When <role> revokes the credential
       Then <role> will get an error stating ...
-      And “Bob” can make a proof with the credential
+      And "Bob" can make a proof with the credential
 
       Examples:
          | issuer | credential_data   | role     | request_for_proof        | presentation            |
@@ -186,10 +190,10 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      Then “Acme” receives an error stating …
-      And “Bob” can make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      Then "Acme" receives an error stating …
+      And "Bob" can make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |
@@ -204,12 +208,12 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      And “Faber” has an issued credential from “Acme" with <credential_data_2>
-      When “Acme” revokes “Bob’s: credential
-      And “Acme” revokes “Faber’s” credential
-      Then “Bob” cannot make a proof with the credential
-      And “Faber” cannot make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      And "Faber" has an issued credential from "Acme" with <credential_data_2>
+      When "Acme" revokes "Bob’s" credential
+      And "Acme" revokes "Faber’s" credential
+      Then "Bob" cannot make a proof with the credential
+      And "Faber" cannot make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |
@@ -224,11 +228,11 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      When “Acme” revokes the credential
-      And “Acme” sends a revocation notification
-      Then “Bob” receives the revocation notification
-      And “Bob" cannot make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      When "Acme" revokes the credential
+      And "Acme" sends a revocation notification
+      Then "Bob" receives the revocation notification
+      And "Bob" cannot make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |
@@ -242,16 +246,16 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Bob   | holder   |
          | Faber | verifier |
       And "Faber" and "Bob" have an existing connection
-      And "Bob" has an issued credential from “Acme" with <credential_data>
-      And “Faber” has an issued credential from “Acme" with <credential_data_2>
-      When “Acme” revokes “Bob’s: credential
-      And “Acme” sends a revocation notification to Bob
-      And “Acme” revokes “Faber’s” credential
-      And “Acme” sends a revocation notification to Faber
-      Then “Bob” receives the revocation notification
-      And “Faber” receives the revocation notification
-      And “Bob” cannot make a proof with the credential
-      And “Faber” cannot make a proof with the credential
+      And "Bob" has an issued credential from "Acme" with <credential_data>
+      And “Faber” has an issued credential from "Acme" with <credential_data_2>
+      When "Acme" revokes "Bob’s" credential
+      And "Acme" sends a revocation notification to "Bob"
+      And "Acme" revokes "Faber’s" credential
+      And "Acme" sends a revocation notification to "Faber"
+      Then "Bob" receives the revocation notification
+      And "Faber" receives the revocation notification
+      And "Bob" cannot make a proof with the credential
+      And "Faber" cannot make a proof with the credential
 
       Examples:
          | issuer | credential_data   | request_for_proof        | presentation            |

--- a/aries-test-harness/features/0037-present-proof.feature
+++ b/aries-test-harness/features/0037-present-proof.feature
@@ -72,6 +72,7 @@ Feature: Aries agent present proof functions RFC 0037
          | issuer | credential_data      | request for proof            | presentation                |
          | Faber  | Data_BI_HealthValues | proof_request_health_consent | presentation_health_consent |
 
+
    # See issue #90 for when work on this test will resume - https://app.zenhub.com/workspaces/von---verifiable-organization-network-5adf53987ccbaa70597dbec0/issues/bcgov/aries-agent-test-harness/90
    @T002-AIP10-RFC0037 @P1 @AcceptanceTest @wip @NeedsReview @Indy
    Scenario Outline: Present Proof where the prover and verifier are connectionless, the prover does not propose a presentation of the proof, and is acknowledged
@@ -160,13 +161,12 @@ Feature: Aries agent present proof functions RFC 0037
       And "Faber" and "Bob" have an existing connection
       And "Bob" has an issued credential from <issuer> with <credential_data>
       When "Faber" sends a <request_for_proof> presentation to "Bob"
-      And "Bob" makes the <presentation> of the proof incorrectly
-      And "Faber" rejects the proof so sends a presentation rejection
+      And "Bob" makes the <presentation> of the proof incorrectly so "Faber" rejects the proof
       Then "Bob" has the proof unacknowledged
 
       Examples:
-         | issuer | credential_data   | request_for_proof        | presentation                |
-         | Acme   | Data_DL_MaxValues | proof_request_DL_address | presentation_DL_age_over_19 |
+         | issuer | credential_data   | request_for_proof        | presentation                      |
+         | Acme   | Data_DL_MaxValues | proof_request_DL_address | presentation_DL_incorrect_address |
 
 
    @T006-AIP10-RFC0037 @P3 @AcceptanceTest @Schema_Health_ID @Indy

--- a/aries-test-harness/features/data/cred_data_schema_driverslicense_revoc.json
+++ b/aries-test-harness/features/data/cred_data_schema_driverslicense_revoc.json
@@ -1,0 +1,25 @@
+{
+   "Data_DL_MaxValues":{
+      "cred_name":"Data_DL_Revoc_MaxValues",
+      "schema_name":"Schema_DriversLicense_revoc",
+      "schema_version":"1.1.0",
+      "attributes":[
+         {
+            "name":"address",
+            "value":"947 this street, Kingston Ontario Canada, K9O 3R5"
+         },
+         {
+            "name":"DL_number",
+            "value":"09385029529385"
+         },
+         {
+            "name":"expiry",
+            "value":"10/12/2022"
+         },
+         {
+            "name":"age",
+            "value":"30"
+         }
+      ]
+   }
+}

--- a/aries-test-harness/features/data/presentation_DL_incorrect_address.json
+++ b/aries-test-harness/features/data/presentation_DL_incorrect_address.json
@@ -1,0 +1,11 @@
+{
+   "presentation": {
+      "comment": "This is a comment for the send presentation.",
+      "requested_attributes": {
+         "address_attrs": {
+            "revealed": true,
+            "cred_id": "d413f359-9595-4ab6-94cf-1aa191d2c884"
+         }
+      }
+   }
+}

--- a/aries-test-harness/features/data/presentation_DL_revoc_address.json
+++ b/aries-test-harness/features/data/presentation_DL_revoc_address.json
@@ -1,0 +1,12 @@
+{
+   "presentation": {
+      "comment": "This is a comment for the send presentation.",
+      "requested_attributes": {
+         "address_attrs": {
+            "cred_type_name": "Schema_DriversLicense_Revoc",
+            "revealed": true,
+            "cred_id": "replace_me"
+         }
+      }
+   }
+}

--- a/aries-test-harness/features/data/proof_request_DL_revoc_address.json
+++ b/aries-test-harness/features/data/proof_request_DL_revoc_address.json
@@ -1,0 +1,16 @@
+{
+   "presentation_proposal": {
+      "requested_attributes": {
+         "address_attrs": {
+            "name": "address",
+            "restrictions": [
+               {
+                  "schema_name": "Schema_DriversLicense_Revoc",
+                  "schema_version": "1.1.0"
+               }
+            ]
+         }
+      },
+      "version": "0.1.0"
+   }
+}

--- a/aries-test-harness/features/data/schema_driverslicense_revoc.json
+++ b/aries-test-harness/features/data/schema_driverslicense_revoc.json
@@ -1,0 +1,13 @@
+{
+   "schema":{
+      "schema_name":"Schema_DriversLicense_Revoc",
+      "schema_version":"1.1.0",
+      "attributes":[
+         "address",
+         "DL_number",
+         "expiry",
+         "age"
+      ]
+   },
+   "cred_def_support_revocation":true
+}

--- a/aries-test-harness/features/environment.py
+++ b/aries-test-harness/features/environment.py
@@ -31,7 +31,7 @@ def before_scenario(context, scenario):
         print ('NOTE: Test \"' + scenario.name + '\" WILL FAIL if your Agent Under Test is not started with or does not support Multi Use Invites.')
 
     # Check for Present Froof Feature to be able to handle the loading of schemas and credential definitions before the scenarios.
-    if 'present proof' in context.feature.name:
+    if 'present proof' in context.feature.name or 'revocation' in context.feature.name:
             # get the tag with "Schema_".
             for tag in context.tags:
                 if 'Schema_' in tag:

--- a/aries-test-harness/features/steps/0011-0183-revocation.py
+++ b/aries-test-harness/features/steps/0011-0183-revocation.py
@@ -1,0 +1,42 @@
+# -----------------------------------------------------------
+# Behave Step Definitions for Credential Revocation 0011 and Revocation Notification Protocol 0183
+# used to revoke issued credentials.
+#
+# GitHub Issue(s) for Test Development:
+# https://app.zenhub.com/workspaces/von---verifiable-organization-network-5adf53987ccbaa70597dbec0/issues/hyperledger/aries-agent-test-harness/102
+#
+# 0011 Revocation RFC: 
+# https://github.com/hyperledger/aries-rfcs/tree/9b0aaa39df7e8bd434126c4b33c097aae78d65bf/features/0160-connection-protocol#0160-connection-protocol
+#
+# 0183 Revocation Notification RFC:
+# https://github.com/hyperledger/aries-rfcs/tree/master/features/0183-revocation-notification
+#
+# Current AIP version level of test coverage: N/A - Revocation is not apart of any AIP Version
+#  
+# -----------------------------------------------------------
+
+from behave import *
+import json
+from agent_backchannel_client import agent_backchannel_GET, agent_backchannel_POST, expected_agent_state
+
+@when('{issuer} revokes the credential')
+def step_impl(context, issuer):
+
+    issuer_url = context.config.userdata.get(issuer)
+
+    credential_revocation = {
+        "cred_rev_id": context.cred_rev_id,
+        "rev_registry_id": context.rev_reg_id,
+        "publish_immediately": True,
+    }
+
+    (resp_status, resp_text) = agent_backchannel_POST(issuer_url + "/agent/command/", "revocation", operation="revoke", data=credential_revocation)
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+    #resp_json = json.loads(resp_text)
+
+    # Check the Holder wallet for the credential
+    # Should be a 200 since the revoke doesn't remove the cred from the holders wallet. 
+    # What else to check?
+    (resp_status, resp_text) = agent_backchannel_GET(context.config.userdata.get(context.holder_name) + "/agent/command/", "credential", id=context.credential_id_dict[context.schema['schema_name']])
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -327,6 +327,16 @@ def step_impl(context, holder):
     # This is returning none instead of Done. Should this be the case. Needs investigation.
     #assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "done")
 
+    # if the credential supports revocation, get the Issuers webhook callback JSON from the store command
+    # From that JSON save off the credential revocation identifier, and the revocation registry identifier.
+    if context.support_revocation:
+        (resp_status, resp_text) = agent_backchannel_GET(context.config.userdata.get(context.issuer_name) + "/agent/response/", "revocation-registry", id=context.cred_thread_id)
+        assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+        resp_json = json.loads(resp_text)
+        context.cred_rev_id = resp_json["revocation_id"]
+        context.rev_reg_id = resp_json["revoc_reg_id"]
+        
+
 @then('"{holder}" has the credential issued')
 def step_impl(context, holder):
 

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -327,6 +327,17 @@ def step_impl(context, holder):
     # This is returning none instead of Done. Should this be the case. Needs investigation.
     #assert expected_agent_state(context.issuer_url, "issue-credential", context.cred_thread_id, "done")
 
+    # if the credential supports revocation, get the Issuers webhook callback JSON from the store command
+    # From that JSON save off the credential revocation identifier, and the revocation registry identifier.
+    if "support_revocation" in context:
+        if context.support_revocation:
+            (resp_status, resp_text) = agent_backchannel_GET(context.config.userdata.get(context.issuer_name) + "/agent/response/", "revocation-registry", id=context.cred_thread_id)
+            assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+            resp_json = json.loads(resp_text)
+            context.cred_rev_id = resp_json["revocation_id"]
+            context.rev_reg_id = resp_json["revoc_reg_id"]
+        
+
 @then('"{holder}" has the credential issued')
 def step_impl(context, holder):
 

--- a/aries-test-harness/features/steps/0036-issue-credential.py
+++ b/aries-test-harness/features/steps/0036-issue-credential.py
@@ -329,7 +329,6 @@ def step_impl(context, holder):
 
     # if the credential supports revocation, get the Issuers webhook callback JSON from the store command
     # From that JSON save off the credential revocation identifier, and the revocation registry identifier.
-<<<<<<< HEAD
     if "support_revocation" in context:
         if context.support_revocation:
             (resp_status, resp_text) = agent_backchannel_GET(context.config.userdata.get(context.issuer_name) + "/agent/response/", "revocation-registry", id=context.cred_thread_id)
@@ -337,14 +336,6 @@ def step_impl(context, holder):
             resp_json = json.loads(resp_text)
             context.cred_rev_id = resp_json["revocation_id"]
             context.rev_reg_id = resp_json["revoc_reg_id"]
-=======
-    if context.support_revocation:
-        (resp_status, resp_text) = agent_backchannel_GET(context.config.userdata.get(context.issuer_name) + "/agent/response/", "revocation-registry", id=context.cred_thread_id)
-        assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
-        resp_json = json.loads(resp_text)
-        context.cred_rev_id = resp_json["revocation_id"]
-        context.rev_reg_id = resp_json["revoc_reg_id"]
->>>>>>> 4eb243abbcb2de5113c093173d5be85e35e9fc76
         
 
 @then('"{holder}" has the credential issued')

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -286,14 +286,9 @@ def step_impl(context, verifier):
     resp_json = json.loads(resp_text)
     assert resp_json["state"] == "done"
 
-<<<<<<< HEAD
     if "support_revocation" in context:
         if context.support_revocation:
             assert resp_json["verified"] == "false"
-=======
-    if context.support_revocation:
-        assert resp_json["verified"] == "false"
->>>>>>> 4eb243abbcb2de5113c093173d5be85e35e9fc76
 
 @then('"{prover}" has the proof acknowledged')
 def step_impl(context, prover):

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -286,6 +286,9 @@ def step_impl(context, verifier):
     resp_json = json.loads(resp_text)
     assert resp_json["state"] == "done"
 
+    if context.support_revocation:
+        assert resp_json["verified"] == "false"
+
 @then('"{prover}" has the proof acknowledged')
 def step_impl(context, prover):
     # check the state of the presentation from the prover's perspective
@@ -429,3 +432,66 @@ def step_impl(context, prover, proposal, verifier=None):
     context.execute_steps('''
         When "''' + prover + '''" doesn’t want to reveal what was requested so makes a presentation proposal
     ''')
+
+
+#
+# Step Definitions to complete the presentation rejection test scenario - T005-AIP10-RFC0037
+#
+@when(u'"{prover}" makes the {presentation} of the proof incorrectly so "{verifier}" rejects the proof')
+def step_impl(context, prover, presentation, verifier):
+    try:
+        presentation_json_file = open('features/data/' + presentation + '.json')
+        presentation_json = json.load(presentation_json_file)
+        context.presentation = presentation_json["presentation"]
+
+    except FileNotFoundError:
+        print(FileNotFoundError + ': features/data/' + presentation + '.json')
+
+    presentation = context.presentation
+    # Find the cred ids and add the actual cred id into the presentation
+    # try:
+    #     for i in range(json.dumps(presentation["requested_attributes"]).count("cred_id")):
+    #         # Get the schema name from the loaded presentation for each requested attributes
+    #         cred_type_name = presentation["requested_attributes"][list(presentation["requested_attributes"])[i]]["cred_type_name"]
+    #         #presentation["requested_attributes"][list(presentation["requested_attributes"])[i]]["cred_id"] = context.credential_id_dict[cred_type_name]
+    #         presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["cred_id"] = '0' 
+    #         # Remove the cred_type_name from this part of the presentation since it won't be needed in the actual request.
+    #         presentation["requested_attributes"][list(presentation["requested_attributes"])[i]].pop("cred_type_name")
+    # except KeyError:
+    #     pass
+    
+    # try:
+    #     for i in range(json.dumps(presentation["requested_predicates"]).count("cred_id")):
+    #         # Get the schema name from the loaded presentation for each requested predicates
+    #         cred_type_name = presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["cred_type_name"]
+    #         #presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["cred_id"] = context.credential_id_dict[cred_type_name]
+    #         presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["cred_id"] = '1' 
+    #         # Remove the cred_type_name from this part of the presentation since it won't be needed in the actual request.
+    #         presentation["requested_predicates"][list(presentation["requested_predicates"])[i]].pop("cred_type_name")
+    # except KeyError:
+    #     pass
+
+    # Change something in the presentation data to cause a problem report
+
+
+    (resp_status, resp_text) = agent_backchannel_POST(context.prover_url + "/agent/command/", "proof", operation="send-presentation", id=context.presentation_thread_id, data=presentation)
+    assert resp_status == 400, f'resp_status {resp_status} is not 400; {resp_text}'
+
+    # check the state of the presentation from the verifier's perspective
+    assert expected_agent_state(context.verifier_url, "proof", context.presentation_thread_id, "presentation-received")
+
+    # context.execute_steps('''
+    #     When "''' + prover + '''" makes the ''' + presentation + ''' of the proof
+    # ''')
+
+# @when(u'"{verifier}" rejects the proof so sends a presentation rejection')
+# def step_impl(context, verifier):
+#     pass
+#     #raise NotImplementedError(u'STEP: When "Faber" rejects the proof so sends a presentation rejection')
+
+@then(u'"{prover}" has the proof unacknowledged')
+def step_impl(context, prover):
+    # check the state of the presentation from the prover's perspective
+    # in the unacknowledged case, the state of the prover is still done. There probably should be something else to check.
+    # like having the verified: false in the repsonse. Change this if agents start to report the verified state. 
+    assert expected_agent_state(context.prover_url, "proof", context.presentation_thread_id, "done")

--- a/manage
+++ b/manage
@@ -234,7 +234,7 @@ startAgent() {
 
   if [ ! "$(docker ps -q -f name=$CONTAINER_NAME)" ]; then
     echo "Starting ${NAME} Agent ..."
-    docker run -d --rm --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" -e "DOCKERHOST=${DOCKERHOST}" -e "LEDGER_URL=http://${DOCKERHOST}:9000" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false >/dev/null
+    docker run -d --rm --name "${CONTAINER_NAME}" --expose "${PORT_RANGE}" -p "${PORT_RANGE}:${PORT_RANGE}" -e "DOCKERHOST=${DOCKERHOST}" -e "LEDGER_URL=http://${DOCKERHOST}:9000" -e "TAILS_SERVER_URL=http://${DOCKERHOST}:6543" "${IMAGE_NAME}" -p "${BACKCHANNEL_PORT}" -i false >/dev/null
   else
     echo "${NAME} Agent already running, skipping..."
   fi


### PR DESCRIPTION
Working revocation test scenario and infrastructure. 
Includes ConfigArgParser in requirements for acapy config files.
Tails server usage integrated into manage script
Updated readme for Tails Server usage
Includes the ability to switch operations if different between Acapy Versions. (this will only work on official releases at this point until master reports something different than the previous release)

