### PR TITLE
adding proper timestamp to T002-RFC011 presentation

### DIFF
--- a/aries-test-harness/agent_test_utils.py
+++ b/aries-test-harness/agent_test_utils.py
@@ -38,3 +38,17 @@ def create_non_revoke_interval(timeframe):
         }
     }
 
+def get_relative_timestamp_to_epoch(timestamp):
+    # timestamps are always relative to now. + or - is represented in seconds from Unix Epoch.
+    # Valid timestsamps are 
+    #  now
+    #  +###### ie +86400
+    #  -###### ie -86400
+
+    if (timestamp == 'now'):
+        epoch_time = int(time.time())
+    else:
+        epoch_time = int(timestamp) + int(time.time())
+
+    return epoch_time
+

--- a/aries-test-harness/features/0011-0183-revocation.feature
+++ b/aries-test-harness/features/0011-0183-revocation.feature
@@ -23,8 +23,8 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
          | Acme   | Data_DL_MaxValues | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
-   @T002-RFC0011 @RFC0011 @P1 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @allure.lable.owner:me
-   Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential
+   @T002-RFC0011 @RFC0011 @P1 @critical @AcceptanceTest @Schema_DriversLicense_Revoc @Indy
+   Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with timesstamp
       Given "2" agents
          | name  | role     |
          | Bob   | prover   |
@@ -39,8 +39,27 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
       Then "Bob" has the proof verified
 
       Examples:
-         | issuer | credential_data   | new_credential_data | request_for_proof              | presentation                  |
-         | Acme   | Data_DL_MinValues | Data_DL_MaxValues   | proof_request_DL_revoc_address | presentation_DL_revoc_address |
+         | issuer | credential_data   | new_credential_data | request_for_proof              | presentation                       |
+         | Acme   | Data_DL_MinValues | Data_DL_MaxValues   | proof_request_DL_revoc_address | presentation_DL_revoc_address_w_ts |
+
+   @T002.1-RFC0011 @RFC0011 @P2 @normal @NegativeTest @AcceptanceTest @Schema_Health_Consent_Revoc @Indy @wip
+   Scenario Outline: Credential revoked and replaced with a new updated credential, holder proves claims with the updated credential with no timestamp
+      Given "2" agents
+         | name  | role     |
+         | Bob   | prover   |
+         | Faber | verifier |
+      And "Faber" and "Bob" have an existing connection
+      And "Bob" has an issued credential from <issuer> with <credential_data>
+      When <issuer> revokes the credential
+      And <issuer> issues a new credential to "Bob" with <new_credential_data>
+      And "Faber" sends a <request_for_proof> presentation to "Bob"
+      And "Bob" makes the <presentation> of the proof
+      And "Faber" acknowledges the proof
+      Then "Bob" has the proof unverified
+
+      Examples:
+         | issuer | credential_data      | new_credential_data          | request_for_proof                         | presentation                             |
+         | Acme   | Data_BI_HealthValues | Data_BI_HealthValues_Reissue | proof_request_health_consent_revoc_expiry | presentation_health_consent_revoc_expiry |
 
 
    @T003-RFC0011 @RFC0011 @P2 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy
@@ -99,7 +118,7 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
       Examples:
          | issuer | credential_data   | timeframe       | request_for_proof              | presentation                  |
          | Acme   | Data_DL_MinValues | -86400:+86400   | proof_request_DL_revoc_address | presentation_DL_revoc_address |
-         | Acme   | Data_DL_MinValues | -604800:now       | proof_request_DL_revoc_address | presentation_DL_revoc_address |
+         | Acme   | Data_DL_MinValues | -604800:now     | proof_request_DL_revoc_address | presentation_DL_revoc_address |
          | Acme   | Data_DL_MinValues | -604800:+604800 | proof_request_DL_revoc_address | presentation_DL_revoc_address |
 
 
@@ -125,7 +144,7 @@ Feature: Aries agent credential revocation and revocation notification RFC 0011 
 
 
    @T007-RFC0011 @RFC0011 @P2 @normal @AcceptanceTest @Schema_DriversLicense_Revoc @Indy @wip @NeedsReview
-   Scenario Outline: Credential is revoked after the timeframe 
+   Scenario Outline: Credential is revoked after the timeframe
       Given "2" agents
          | name  | role     |
          | Bob   | prover   |

--- a/aries-test-harness/features/data/cred_data_schema_health_consent_revoc.json
+++ b/aries-test-harness/features/data/cred_data_schema_health_consent_revoc.json
@@ -1,0 +1,56 @@
+{
+   "Data_BI_HealthValues":{
+      "cred_name":"Data_HealthConsent_NormalizedValues",
+      "schema_name":"Schema_Health_Consent_Revoc",
+      "schema_version":"1.2.0",
+      "attributes":[
+         {
+            "name":"name",
+            "value":"Big Data Consent Firm"
+         },
+         {
+            "name":"jti_id",
+            "value":"97375899098359893987267983990020"
+         },
+         {
+            "name":"expiry",
+            "value":"04/02/2021"
+         },
+         {
+            "name":"phone",
+            "value":"x"
+         },
+         {
+            "name":"consented_on",
+            "value":"04/02/2020"
+         }
+      ]
+   },
+   "Data_BI_HealthValues_Reissue":{
+      "cred_name":"Data_HealthConsent_NormalizedValues",
+      "schema_name":"Schema_Health_Consent_Revoc",
+      "schema_version":"1.2.0",
+      "attributes":[
+         {
+            "name":"name",
+            "value":"Bob Givesconsent"
+         },
+         {
+            "name":"jti_id",
+            "value":"998273597238957298375982"
+         },
+         {
+            "name":"expiry",
+            "value":"04/02/2022"
+         },
+         {
+            "name":"phone",
+            "value":"5555555555"
+         },
+         {
+            "name":"consented_on",
+            "value":"11/11/2020"
+         }
+      ]
+   }
+}

--- a/aries-test-harness/features/data/presentation_DL_revoc_address_w_ts.json
+++ b/aries-test-harness/features/data/presentation_DL_revoc_address_w_ts.json
@@ -1,0 +1,13 @@
+{
+   "presentation": {
+      "comment": "This is a comment for the send presentation.",
+      "requested_attributes": {
+         "address_attrs": {
+            "cred_type_name": "Schema_DriversLicense_Revoc",
+            "revealed": true,
+            "cred_id": "replace_me",
+            "timestamp": "now"
+         }
+      }
+   }
+}

--- a/aries-test-harness/features/data/presentation_health_consent_revoc_expiry.json
+++ b/aries-test-harness/features/data/presentation_health_consent_revoc_expiry.json
@@ -1,0 +1,14 @@
+{
+    "presentation": {
+        "comment": "This is a comment for the send presentation for the Health Consent Proof.",
+        "requested_attributes": {
+            "consent_attrs": {
+                "cred_type_name": "Schema_Health_Consent_Revoc",
+                "cred_id": "replace me",
+                "revealed": true
+            }
+        },
+        "requested_predicates": {},
+        "self_attested_attributes": {}
+    }
+}

--- a/aries-test-harness/features/data/proof_request_health_consent_revoc_expiry.json
+++ b/aries-test-harness/features/data/proof_request_health_consent_revoc_expiry.json
@@ -1,0 +1,18 @@
+{
+    "presentation_proposal": {
+        "name": "Health Consent Proof",
+        "requested_attributes": {
+            "consent_attrs": {
+                "name": "expiry",
+                "restrictions": [
+                    {
+                        "schema_name": "Schema_Health_Consent_Revoc",
+                        "schema_version": "1.2.0"
+                    }
+                ]
+            }
+        },
+        "requested_predicates": {},
+        "version": "0.1.0"
+    }
+}

--- a/aries-test-harness/features/data/schema_health_consent_revoc.json
+++ b/aries-test-harness/features/data/schema_health_consent_revoc.json
@@ -1,0 +1,14 @@
+{
+   "schema":{
+      "schema_name":"Schema_Health_Consent_Revoc",
+      "schema_version":"1.2.0",
+      "attributes":[
+         "name",
+         "jti_id",
+         "expiry",
+         "phone",
+         "consented_on"
+      ]
+   },
+   "cred_def_support_revocation":true
+}

--- a/aries-test-harness/features/steps/0037-present-proof.py
+++ b/aries-test-harness/features/steps/0037-present-proof.py
@@ -1,6 +1,7 @@
 from behave import *
 import json
 from agent_backchannel_client import agent_backchannel_GET, agent_backchannel_POST, expected_agent_state
+from agent_test_utils import get_relative_timestamp_to_epoch
 from time import sleep
 
 @when('{issuer} issues a new credential to "{prover}" with {credential_data}')
@@ -221,6 +222,10 @@ def step_impl(context, prover):
                 # Get the schema name from the loaded presentation for each requested attributes
                 cred_type_name = presentation["requested_attributes"][list(presentation["requested_attributes"])[i]]["cred_type_name"]
                 presentation["requested_attributes"][list(presentation["requested_attributes"])[i]]["cred_id"] = context.credential_id_dict[cred_type_name][len(context.credential_id_dict[cred_type_name])-1]
+                # If there is a timestamp, calculate it from the instruction in the file. Can be 'now' or + - relative to now.
+                if ("timestamp" in presentation["requested_attributes"][list(presentation["requested_attributes"])[i]]):
+                    relative_timestamp = presentation["requested_attributes"][list(presentation["requested_attributes"])[i]]["timestamp"]
+                    presentation["requested_attributes"][list(presentation["requested_attributes"])[i]]["timestamp"] = get_relative_timestamp_to_epoch(relative_timestamp)
                 # Remove the cred_type_name from this part of the presentation since it won't be needed in the actual request.
                 presentation["requested_attributes"][list(presentation["requested_attributes"])[i]].pop("cred_type_name")
         except KeyError:
@@ -231,6 +236,10 @@ def step_impl(context, prover):
                 # Get the schema name from the loaded presentation for each requested predicates
                 cred_type_name = presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["cred_type_name"]
                 presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["cred_id"] = context.credential_id_dict[cred_type_name][len(context.credential_id_dict[cred_type_name])-1] 
+                # If there is a timestamp, calculate it from the instruction in the file. Can be 'now' or + - relative to now.
+                if ("timestamp" in presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]):
+                    relative_timestamp = presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["timestamp"]
+                    presentation["requested_predicates"][list(presentation["requested_predicates"])[i]]["timestamp"] = get_relative_timestamp_to_epoch(relative_timestamp)
                 # Remove the cred_type_name from this part of the presentation since it won't be needed in the actual request.
                 presentation["requested_predicates"][list(presentation["requested_predicates"])[i]].pop("cred_type_name")
         except KeyError:


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

In an effort to fix a problem with a revocation test using a dotnet agent, timestamps in presentations were added there. It ultimately didn't fix the problem with dotnet. That agent has something wrong in this regard. Further investigation into the dotnet agent is required. 
Adding the timestamp enhancements to the test harness still should be committed at this time.